### PR TITLE
Handle re-signup for pending subscriptions by creating a PUT request

### DIFF
--- a/Classes/Service/ApiService.php
+++ b/Classes/Service/ApiService.php
@@ -118,9 +118,9 @@ class ApiService
                 } else {
                   throw new MemberExistsException($response['detail']);
                 }
+            } else {
+                throw new GeneralException($response['detail']);
             }
-
-            throw new GeneralException($response['detail']);
         }
     }
 

--- a/Classes/Service/ApiService.php
+++ b/Classes/Service/ApiService.php
@@ -112,7 +112,12 @@ class ApiService
             $this->logger->error($response['status'] . ' ' . $response['detail']);
             $this->logger->error($response['detail'], (array)$response['errors']);
             if ($response['title'] === 'Member Exists') {
-                throw new MemberExistsException($response['detail']);
+                $getResponse = $this->api->get("lists/$listId/members/" . $this->api->subscriberHash($data['email_address']));
+                if ($getResponse['status'] !== 'subscribed') {
+                    $this->api->put("lists/$listId/members/" . $this->api->subscriberHash($data['email_address']), $data);
+                } else {
+                  throw new MemberExistsException($response['detail']);
+                }
             }
 
             throw new GeneralException($response['detail']);
@@ -130,7 +135,7 @@ class ApiService
             'email_address' => $form->getEmail(),
             'status' => 'pending',
             'merge_fields' => array(
-				'FNAME' => (!empty($form->getFirstName())) ? $form->getFirstName() : '',
+				        'FNAME' => (!empty($form->getFirstName())) ? $form->getFirstName() : '',
                 'LNAME' => (!empty($form->getLastName())) ? $form->getLastName() : '',
             )
         );


### PR DESCRIPTION
**Situation:**
Double opt-in which requires an e-mail verification. User doesn't get
the e-mail (spam filter, temporary error etc.) and never confirms.
Later the user retries the signup process, but MailChimp will report
"already signed up" even though the signup is pending.

**Solution:**
If the user is not already fully subscribed, send a PUT request to
MailChimp. This will trigger the signup mail again and solve the signup
limbo.

If the user is already fully subscribed nothing, the existing
subscription is not touched and the existing "error message" is shown.