### PR TITLE
Enable curl proxy

### DIFF
--- a/Classes/Domain/Model/Dto/ExtensionConfiguration.php
+++ b/Classes/Domain/Model/Dto/ExtensionConfiguration.php
@@ -10,6 +10,16 @@ class ExtensionConfiguration
     /** @var string */
     protected $apiKey;
 
+    /**
+     * @var string
+     */
+    protected $proxy = '';
+
+    /**
+     * @var string
+     */
+    protected $proxyPort = '';
+
     public function __construct()
     {
         $settings = (array)unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['mailchimp']);
@@ -31,4 +41,20 @@ class ExtensionConfiguration
         }
         return $this->apiKey;
     }
+
+    /**
+     * @return string
+     */
+    public function getProxy() {
+        return $this->proxy;
+    }
+
+    /**
+     * @return string
+     */
+    public function getProxyPort() {
+        return $this->proxyPort;
+    }
+
+
 }

--- a/Classes/Service/ApiService.php
+++ b/Classes/Service/ApiService.php
@@ -25,8 +25,10 @@ class ApiService
         /** @var \Sup7even\Mailchimp\Domain\Model\Dto\ExtensionConfiguration $extensionConfiguration */
         $extensionConfiguration = GeneralUtility::makeInstance('Sup7even\\Mailchimp\\Domain\\Model\\Dto\\ExtensionConfiguration');
         $apiKey = $extensionConfiguration->getApiKey();
+        $curlProxy = $extensionConfiguration->getProxy();
+        $curlProxyPort = $extensionConfiguration->getProxyPort();
 
-        $this->api = new MailChimp($apiKey);
+        $this->api = new MailChimp($apiKey, $curlProxy, $curlProxyPort);
         $this->logger = GeneralUtility::makeInstance('TYPO3\CMS\Core\Log\LogManager')->getLogger(__CLASS__);
     }
 

--- a/Resources/Private/Language/locallang.xml
+++ b/Resources/Private/Language/locallang.xml
@@ -14,6 +14,8 @@
             <label index="flexform.interests">Interests</label>
             <label index="flexform.useAjax">Use Ajax (EXT:typoscript_rendering required)</label>
             <label index="extMgm.apiKey">API key:You get the API key at mailchimp.com > Account > Extras > API keys</label>
+            <label index="extMgm.proxy">If you have to use a proxy for curl enter it here</label>
+            <label index="extMgm.proxyPort">Enter the proxy port for here</label>
 
             <!-- Frontend -->
             <label index="field.email">Email</label>

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,3 +1,9 @@
 
 # cat=general/enable/1; type=string; label=LLL:EXT:mailchimp/Resources/Private/Language/locallang.xml:extMgm.apiKey
 apiKey =
+
+# cat=general/enable/1; type=string; label=LLL:EXT:mailchimp/Resources/Private/Language/locallang.xml:extMgm.proxy
+proxy =
+
+# cat=general/enable/1; type=string; label=LLL:EXT:mailchimp/Resources/Private/Language/locallang.xml:extMgm.proxyPort
+proxyPort =


### PR DESCRIPTION
Make curl proxy settings available via extension configuration. This might be needed, if there are restrictions like a WAF which disallow direct curl connections to external resources.