### PR TITLE
Added a way to override the extensionmanagerconfiguration

### DIFF
--- a/Classes/Domain/Model/Dto/ExtensionConfiguration.php
+++ b/Classes/Domain/Model/Dto/ExtensionConfiguration.php
@@ -3,6 +3,9 @@
 namespace Sup7even\Mailchimp\Domain\Model\Dto;
 
 use Sup7even\Mailchimp\Exception\ApiKeyMissingException;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
 
 class ExtensionConfiguration
 {
@@ -22,10 +25,18 @@ class ExtensionConfiguration
 
     public function __construct()
     {
+        $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
+        $configurationManager = $objectManager->get(ConfigurationManagerInterface::class);
+        $typoScript = $configurationManager->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT)["plugin."]["tx_mailchimp."]["settings."];
+
         $settings = (array)unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['mailchimp']);
         foreach ($settings as $key => $value) {
             if (property_exists(__CLASS__, $key)) {
-                $this->$key = $value;
+                if (empty($typoScript[$key])) {
+                    $this->$key = $value;
+                } else {
+                    $this->$key = $typoScript[$key];
+                }
             }
         }
     }
@@ -45,16 +56,17 @@ class ExtensionConfiguration
     /**
      * @return string
      */
-    public function getProxy() {
+    public function getProxy()
+    {
         return $this->proxy;
     }
 
     /**
      * @return string
      */
-    public function getProxyPort() {
+    public function getProxyPort()
+    {
         return $this->proxyPort;
     }
-
 
 }

--- a/Configuration/TypoScript/constants.txt
+++ b/Configuration/TypoScript/constants.txt
@@ -1,0 +1,7 @@
+plugin.tx_mailchimp {
+	settings {
+	    apiKey =
+	    proxy  =
+	    proxyPort =
+	}
+}

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -1,0 +1,8 @@
+plugin.tx_mailchimp {
+	settings {
+		apiKey = {$plugin.tx_mailchimp.settings.apiKey}
+		proxy = {$plugin.tx_mailchimp.settings.proxy}
+		proxyPort = {$plugin.tx_mailchimp.settings.proxyPort}
+	}
+}
+

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -30,3 +30,6 @@ if (TYPO3_MODE === 'BE') {
 }
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig('<INCLUDE_TYPOSCRIPT: source="FILE:EXT:mailchimp/Configuration/TSconfig/ContentElementWizard.txt">');
+
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile($_EXTKEY, 'Configuration/TypoScript', 'mailchimp');
+


### PR DESCRIPTION
This resolves #10
It is now possible to override the extensionmanagerconfiguration with typoscript.
