### PR TITLE
Remove index from non cacheable Form action

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -9,7 +9,7 @@ if (!defined('TYPO3_MODE')) {
         'Form' => 'index,response,ajaxResponse'
     ],
     [
-        'Form' => 'index,response,ajaxResponse'
+        'Form' => 'response,ajaxResponse'
     ]
 );
 


### PR DESCRIPTION
Hey there,

First sorry for what could looked like a messy commit history. Didn't get this one started off in a branch, but the change is a one liner so I hope it's cool.

I'm not 100% sure if there's some downside with this but after trying various things, the was the only thing that worked.

**Situation:**

We run a signup form on all pages on the site creating the form using TS so we can show it in the footer and as a popover in some page views:

```
lib.footerMailChimp = USER
lib.footerMailChimp {
  userFunc = TYPO3\CMS\Extbase\Core\Bootstrap->run
  pluginName = Registration
  extensionName = Mailchimp
  vendorName = Sup7even
  controller = Form
  settings =< plugin.tx_mailchimp.settings
  view =< plugin.tx_mailchimp.view
  view.templateRootPaths.1 = path/to/our/template/mailchimp/Footer/Templates/
  view.layoutRootPaths.1 = path/to/our/template/mailchimp/Footer/Layouts/
}
```

After moving to a new platform that includes Varnish caching, we noticed that all pages were missing the cache and so a `USER_INT` must be in play. Revising everything it turns out that the form is being created as `USER_INT` for some reason I don't understand.

Seems like there's no reason for that and so this PR is to remove it from the configurePlugin, as it will then render as a `USER` object.

If there's another way to force it as a `USER` without changing this, please let me know but I did some tests and it looks like the form works just fine (both with and without AJAX enabled) running as `USER`.