### PR TITLE
[BUGFIX]

### DIFF
--- a/Classes/Hooks/Backend/ItemsProcFunc.php
+++ b/Classes/Hooks/Backend/ItemsProcFunc.php
@@ -99,7 +99,7 @@ class ItemsProcFunc
      * @param int $elementId
      * @return array
      */
-    private function extractSettingsFromRecord(int $elementId)
+    private function extractSettingsFromRecord($elementId)
     {
         $contentElement = BackendUtility::getRecord('tt_content', $elementId);
 

--- a/Classes/Hooks/Backend/ItemsProcFunc.php
+++ b/Classes/Hooks/Backend/ItemsProcFunc.php
@@ -119,7 +119,6 @@ class ItemsProcFunc
         return GeneralUtility::makeInstance(ApiService::class, $hash);
     }
 
-
     /**
      * @return LanguageService
      */


### PR DESCRIPTION
remove scalar type hint for PHP 5 compatibility

fix error message when using in backend on PHP 5.6