### PR TITLE
[FEATURE] ext:form Finisher support

### DIFF
--- a/Classes/Domain/Finishers/MailchimpFinisher.php
+++ b/Classes/Domain/Finishers/MailchimpFinisher.php
@@ -55,6 +55,7 @@ class MailchimpFinisher extends AbstractFinisher
         if ($this->parseOption('skip_double_optin') == 1) {
             $doublOptIn = false;
         }
+
         try {
             $apiService = $this->getApiService($this->parseOption('api_key') ?? '');
             $apiService->register($listId, $form, $doublOptIn);

--- a/Classes/Domain/Finishers/MailchimpFinisher.php
+++ b/Classes/Domain/Finishers/MailchimpFinisher.php
@@ -20,7 +20,18 @@ class MailchimpFinisher extends AbstractFinisher
         $form->setEmail($this->parseOption('email'));
         $form->setFirstName($this->parseOption('first_name'));
         $form->setLastName($this->parseOption('last_name'));
-        $form->setInterest($this->parseOption('interest') ?? '');
+
+        $interests = $this->parseOption('interests');
+
+        if (is_string($interests)) {
+            $form->setInterest($interests);
+        } else {
+            $remapInterests = array();
+            foreach ($interests as $interest) {
+                $remapInterests[$interest] = true;
+            }
+            $form->setInterests($remapInterests);
+        }
 
         return $this->handleRegistration($form);
     }
@@ -58,5 +69,13 @@ class MailchimpFinisher extends AbstractFinisher
         ]);
 
         return $view->render();
+    }
+
+    public function getCategories()
+    {
+        return $this->getApiService($this->options['api_key'])->getCategories(
+            $this->options['list_id'], 
+            $this->options['interest_id']
+        );
     }
 }

--- a/Classes/Domain/Finishers/MailchimpFinisher.php
+++ b/Classes/Domain/Finishers/MailchimpFinisher.php
@@ -4,20 +4,59 @@ namespace Sup7even\Mailchimp\Domain\Finishers;
 
 use TYPO3\CMS\Form\Domain\Finishers\AbstractFinisher;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use Sup7even\Mailchimp\Domain\Model\Dto\ExtensionConfiguration;
+use TYPO3\CMS\Fluid\View\StandaloneView;
+use Sup7even\Mailchimp\Domain\Model\Dto\FormDto;
 use Sup7even\Mailchimp\Service\ApiService;
+use Sup7even\Mailchimp\Exception\MemberExistsException;
+use Sup7even\Mailchimp\Exception\GeneralException;
 
 class MailchimpFinisher extends AbstractFinisher
 {
     protected function executeInternal()
     {
-        /** @var ExtensionConfiguration */
-        $configuration = GeneralUtility::makeInstance(ExtensionConfiguration::class);
-        $service = $this->getApiService();
+        /** @var FormDto */
+        $form = GeneralUtility::makeInstance(FormDto::class);
+
+        $form->setEmail($this->parseOption('email'));
+        $form->setFirstName($this->parseOption('first_name'));
+        $form->setLastName($this->parseOption('last_name'));
+        $form->setInterest($this->parseOption('interest') ?? '');
+
+        return $this->handleRegistration($form);
     }
 
     private function getApiService(string $hash = null): ApiService
     {
         return GeneralUtility::makeInstance(ApiService::class, $hash);
+    }
+
+    protected function handleRegistration(FormDto $form = null)
+    {
+        /** @var StandaloneView */
+        $view = GeneralUtility::makeInstance(StandaloneView::class);
+
+        $view->setTemplate($this->options['templateName']);
+        $view->getRequest()->setControllerExtensionName('mailchimp');
+        $view->getTemplatePaths()->fillFromConfigurationArray($this->options);
+
+        $listId = $this->parseOption('list_id');
+        $doublOptIn = true;
+        if ($this->parseOption('skip_double_optin') == 1) {
+            $doublOptIn = false;
+        }
+        try {
+            $apiService = $this->getApiService($this->parseOption('api_key') ?? '');
+            $apiService->register($listId, $form, $doublOptIn);
+        } catch (MemberExistsException $e) {
+            $view->assign('error', 'memberExists');
+        } catch (GeneralException $e) {
+            $view->assign('error', 'general');
+        }
+
+        $view->assignMultiple([
+            'form' => $form
+        ]);
+
+        return $view->render();
     }
 }

--- a/Classes/Domain/Finishers/MailchimpFinisher.php
+++ b/Classes/Domain/Finishers/MailchimpFinisher.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Sup7even\Mailchimp\Domain\Finishers;
+
+use TYPO3\CMS\Form\Domain\Finishers\AbstractFinisher;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use Sup7even\Mailchimp\Domain\Model\Dto\ExtensionConfiguration;
+use Sup7even\Mailchimp\Service\ApiService;
+
+class MailchimpFinisher extends AbstractFinisher
+{
+    protected function executeInternal()
+    {
+        /** @var ExtensionConfiguration */
+        $configuration = GeneralUtility::makeInstance(ExtensionConfiguration::class);
+        $service = $this->getApiService();
+    }
+
+    private function getApiService(string $hash = null): ApiService
+    {
+        return GeneralUtility::makeInstance(ApiService::class, $hash);
+    }
+}

--- a/Classes/Domain/Finishers/MailchimpFinisher.php
+++ b/Classes/Domain/Finishers/MailchimpFinisher.php
@@ -2,13 +2,13 @@
 
 namespace Sup7even\Mailchimp\Domain\Finishers;
 
-use TYPO3\CMS\Form\Domain\Finishers\AbstractFinisher;
+use Sup7even\Mailchimp\Domain\Model\Dto\FormDto;
+use Sup7even\Mailchimp\Exception\GeneralException;
+use Sup7even\Mailchimp\Exception\MemberExistsException;
+use Sup7even\Mailchimp\Service\ApiService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Fluid\View\StandaloneView;
-use Sup7even\Mailchimp\Domain\Model\Dto\FormDto;
-use Sup7even\Mailchimp\Service\ApiService;
-use Sup7even\Mailchimp\Exception\MemberExistsException;
-use Sup7even\Mailchimp\Exception\GeneralException;
+use TYPO3\CMS\Form\Domain\Finishers\AbstractFinisher;
 
 class MailchimpFinisher extends AbstractFinisher
 {
@@ -26,7 +26,7 @@ class MailchimpFinisher extends AbstractFinisher
         if (is_string($interests)) {
             $form->setInterest($interests);
         } else {
-            $remapInterests = array();
+            $remapInterests = [];
             foreach ($interests as $interest) {
                 $remapInterests[$interest] = true;
             }
@@ -65,7 +65,7 @@ class MailchimpFinisher extends AbstractFinisher
         }
 
         $view->assignMultiple([
-            'form' => $form
+            'form' => $form,
         ]);
 
         return $view->render();
@@ -74,7 +74,7 @@ class MailchimpFinisher extends AbstractFinisher
     public function getCategories()
     {
         return $this->getApiService($this->options['api_key'])->getCategories(
-            $this->options['list_id'], 
+            $this->options['list_id'],
             $this->options['interest_id']
         );
     }

--- a/Classes/Domain/Model/FormElements/Interests.php
+++ b/Classes/Domain/Model/FormElements/Interests.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Sup7even\Mailchimp\Domain\Model\FormElements;
+
+use TYPO3\CMS\Form\Domain\Model\FormElements\AbstractFormElement;
+use TYPO3\CMS\Form\Domain\Model\FormElements\Section;
+use TYPO3\CMS\Form\Domain\Model\FormElements\Page;
+
+class Interests extends AbstractFormElement
+{
+    public function initializeFormElement()
+    {
+        parent::initializeFormElement();
+    }
+}

--- a/Classes/Domain/Model/FormElements/Interests.php
+++ b/Classes/Domain/Model/FormElements/Interests.php
@@ -12,4 +12,9 @@ class Interests extends AbstractFormElement
     {
         parent::initializeFormElement();
     }
+
+    public function useGroupNameAsLabel()
+    {
+        return $this->properties['useGroupName'];
+    }
 }

--- a/Classes/Domain/Model/FormElements/Interests.php
+++ b/Classes/Domain/Model/FormElements/Interests.php
@@ -3,8 +3,6 @@
 namespace Sup7even\Mailchimp\Domain\Model\FormElements;
 
 use TYPO3\CMS\Form\Domain\Model\FormElements\AbstractFormElement;
-use TYPO3\CMS\Form\Domain\Model\FormElements\Section;
-use TYPO3\CMS\Form\Domain\Model\FormElements\Page;
 
 class Interests extends AbstractFormElement
 {

--- a/Classes/Hooks/Backend/ItemsProcFunc.php
+++ b/Classes/Hooks/Backend/ItemsProcFunc.php
@@ -20,7 +20,7 @@ class ItemsProcFunc
     }
 
     /**
-     * Get API keys and its labels
+     * Get API keys and its labels.
      *
      * @throws ApiKeyMissingException
      */
@@ -40,8 +40,9 @@ class ItemsProcFunc
     public function getLists(array &$config): void
     {
         $apiKeyHash = null;
+
         try {
-            $elementId = (int)$config['row']['uid'];
+            $elementId = (int) $config['row']['uid'];
             if ($elementId > 0) {
                 $settings = $this->extractSettingsFromRecord($elementId);
                 $settings['apiKey'] = $settings['apiKey'] ?? $settings['finishers']['Mailchimp']['api_key'] ?? null;
@@ -61,7 +62,7 @@ class ItemsProcFunc
 
     public function getInterests(array &$config): void
     {
-        $elementId = (int)$config['row']['uid'];
+        $elementId = (int) $config['row']['uid'];
         if ($elementId > 0) {
             $settings = $this->extractSettingsFromRecord($elementId);
             $settings['listId'] = $settings['listId'] ?? $settings['finishers']['Mailchimp']['list_id'] ?? null;
@@ -84,7 +85,7 @@ class ItemsProcFunc
     }
 
     /**
-     * Get settings from given content element uid
+     * Get settings from given content element uid.
      */
     private function extractSettingsFromRecord(int $elementId): array
     {
@@ -94,11 +95,13 @@ class ItemsProcFunc
         if (!isset($settings['settings'])) {
             return [];
         }
+
         return $settings['settings'];
     }
 
     /**
      * @param string|null $hash
+     *
      * @return ApiService
      */
     private function getApiService(string $hash = null)

--- a/Classes/Hooks/Backend/ItemsProcFunc.php
+++ b/Classes/Hooks/Backend/ItemsProcFunc.php
@@ -44,8 +44,8 @@ class ItemsProcFunc
             $elementId = (int)$config['row']['uid'];
             if ($elementId > 0) {
                 $settings = $this->extractSettingsFromRecord($elementId);
-                $settings['apiKey'] = $settings['apiKey'] ?? $settings['finishers']['Mailchimp']['api_key'];
-                $apiKeyHash = isset($settings['apiKey']) ? $settings['apiKey'] : null;
+                $settings['apiKey'] = $settings['apiKey'] ?? $settings['finishers']['Mailchimp']['api_key'] ?? null;
+                $apiKeyHash = $settings['apiKey'] ?? null;
             }
 
             $api = $this->getApiService($apiKeyHash);
@@ -64,7 +64,7 @@ class ItemsProcFunc
         $elementId = (int)$config['row']['uid'];
         if ($elementId > 0) {
             $settings = $this->extractSettingsFromRecord($elementId);
-            $settings['listId'] = $settings['listId'] ?? $settings['finishers']['Mailchimp']['list_id'];
+            $settings['listId'] = $settings['listId'] ?? $settings['finishers']['Mailchimp']['list_id'] ?? null;
 
             if ($settings['listId'] ?? false) {
                 try {

--- a/Classes/Hooks/Backend/ItemsProcFunc.php
+++ b/Classes/Hooks/Backend/ItemsProcFunc.php
@@ -44,7 +44,8 @@ class ItemsProcFunc
             $elementId = (int)$config['row']['uid'];
             if ($elementId > 0) {
                 $settings = $this->extractSettingsFromRecord($elementId);
-                $apiKeyHash = $settings['apiKey'] ?? null;
+                $settings['apiKey'] = $settings['apiKey'] ?? $settings['finishers']['Mailchimp']['api_key'];
+                $apiKeyHash = isset($settings['apiKey']) ? $settings['apiKey'] : null;
             }
 
             $api = $this->getApiService($apiKeyHash);
@@ -63,6 +64,7 @@ class ItemsProcFunc
         $elementId = (int)$config['row']['uid'];
         if ($elementId > 0) {
             $settings = $this->extractSettingsFromRecord($elementId);
+            $settings['listId'] = $settings['listId'] ?? $settings['finishers']['Mailchimp']['list_id'];
 
             if ($settings['listId'] ?? false) {
                 try {

--- a/Classes/Hooks/Frontend/Form.php
+++ b/Classes/Hooks/Frontend/Form.php
@@ -28,6 +28,11 @@ class Form
                     $renderable->setProperty('options', $categories['options']);
                     $renderable->setProperty('title', $categories['title']);
                     $renderable->setProperty('type', $categories['type']);
+
+                    $useGroupName = $renderable->useGroupNameAsLabel();
+                    if ($useGroupName) {
+                        $renderable->setLabel($categories['title']);
+                    }
                 }
             }
         

--- a/Classes/Hooks/Frontend/Form.php
+++ b/Classes/Hooks/Frontend/Form.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Sup7even\Mailchimp\Hooks\Frontend;
+
+use TYPO3\CMS\Form\Domain\Model\FormElements\GenericFormElement;
+use TYPO3\CMS\Form\Domain\Model\Renderable\RenderableInterface;
+use TYPO3\CMS\Form\Domain\Finishers\AbstractFinisher;
+use TYPO3\CMS\Form\Domain\Finishers\FinisherInterface;
+use Sup7even\Mailchimp\Domain\Model\FormElements\Interests;
+use Sup7even\Mailchimp\Domain\Finishers\MailchimpFinisher;
+
+class Form
+{
+    public function afterBuildingFinished(\TYPO3\CMS\Form\Domain\Model\Renderable\RenderableInterface $renderable)
+    {
+        if ($renderable->getType() === 'Interests') {
+            /** @var Interests $renderable */
+            
+            $finishers = $renderable->getRootForm()->getFinishers();
+
+            /** @var AbstractFinisher $finisher */
+            foreach ($finishers as &$finisher) {
+                if ($finisher->getFinisherIdentifier() === 'Mailchimp') {
+                    /** @var MailchimpFinisher $finisher */
+
+                    $categories = $finisher->getCategories();
+
+                    $renderable->setProperty('options', $categories['options']);
+                    $renderable->setProperty('title', $categories['title']);
+                    $renderable->setProperty('type', $categories['type']);
+                }
+            }
+        
+        }
+    }
+}

--- a/Classes/Hooks/Frontend/Form.php
+++ b/Classes/Hooks/Frontend/Form.php
@@ -2,12 +2,9 @@
 
 namespace Sup7even\Mailchimp\Hooks\Frontend;
 
-use TYPO3\CMS\Form\Domain\Model\FormElements\GenericFormElement;
-use TYPO3\CMS\Form\Domain\Model\Renderable\RenderableInterface;
-use TYPO3\CMS\Form\Domain\Finishers\AbstractFinisher;
-use TYPO3\CMS\Form\Domain\Finishers\FinisherInterface;
-use Sup7even\Mailchimp\Domain\Model\FormElements\Interests;
 use Sup7even\Mailchimp\Domain\Finishers\MailchimpFinisher;
+use Sup7even\Mailchimp\Domain\Model\FormElements\Interests;
+use TYPO3\CMS\Form\Domain\Finishers\AbstractFinisher;
 
 class Form
 {
@@ -15,14 +12,12 @@ class Form
     {
         if ($renderable->getType() === 'Interests') {
             /** @var Interests $renderable */
-            
             $finishers = $renderable->getRootForm()->getFinishers();
 
             /** @var AbstractFinisher $finisher */
             foreach ($finishers as &$finisher) {
                 if ($finisher->getFinisherIdentifier() === 'Mailchimp') {
                     /** @var MailchimpFinisher $finisher */
-
                     $categories = $finisher->getCategories();
 
                     $renderable->setProperty('options', $categories['options']);
@@ -35,7 +30,6 @@ class Form
                     }
                 }
             }
-        
         }
     }
 }

--- a/Configuration/Yaml/Finishers/Mailchimp.yaml
+++ b/Configuration/Yaml/Finishers/Mailchimp.yaml
@@ -10,6 +10,7 @@ TYPO3:
                 templateName: Response
                 templateRootPaths:
                   10: 'EXT:mailchimp/Resources/Private/Templates/Form/'
+                interests: ''
               formEditor:
                 iconIdentifier: form-finisher
                 label: plugin.title
@@ -22,6 +23,7 @@ TYPO3:
                     api_key: ''
                     list_id: ''
                     interest_id: ''
+                    interests: ''
               FormEngine:
                 label: plugin.title
                 elements:
@@ -74,3 +76,7 @@ TYPO3:
                           -
                       itemsProcFunc:
                         'Sup7even\Mailchimp\Hooks\Backend\ItemsProcFunc->getInterests'
+                  interests:
+                    label: Interest choices
+                    config:
+                      type: input

--- a/Configuration/Yaml/Finishers/Mailchimp.yaml
+++ b/Configuration/Yaml/Finishers/Mailchimp.yaml
@@ -6,30 +6,60 @@ TYPO3:
           finishersDefinition:
             Mailchimp:
               implementationClassName: Sup7even\Mailchimp\Domain\Finishers\MailchimpFinisher
-              options: 
-                first_name: ''
-                last_name: ''
-                email: ''
+              options:
+                templateName: Response
+                templateRootPaths:
+                  10: 'EXT:mailchimp/Resources/Private/Templates/Form/'
               formEditor:
                 iconIdentifier: form-finisher
-                label: formEditor.elements.Form.finisher.Mailchimp.editor.header.label
+                label: plugin.title
                 predefinedDefaults:
                   options:
                     first_name: ''
                     last_name: ''
                     email: ''
+                    skip_double_optin: false
+                    api_key: ''
+                    list_id: ''
+                    interest_id: ''
               FormEngine:
-                label: formEditor.elements.Form.finisher.Mailchimp.editor.header.label
+                label: plugin.title
                 elements:
                   first_name:
-                    label: formEditor.elements.Form.finisher.Mailchimp.editor.first_name.label
+                    label: field.firstName
                     config:
                       type: input
                   last_name:
-                    label: formEditor.elements.Form.finisher.Mailchimp.editor.last_name.label
+                    label: field.lastName
                     config:
                       type: input
                   email:
-                    label: formEditor.elements.Form.finisher.Mailchimp.editor.email.label
+                    label: field.email
                     config:
                       type: input
+                  skip_double_optin:
+                    label: field.skipDoubleOptin
+                    config:
+                      type: check
+                      default: 0
+                  api_key:
+                    label: flexform.apiKey
+                    config:
+                      type: select
+                      renderType: selectSingle
+                      itemsProcFunc:
+                        'Sup7even\Mailchimp\Hooks\Backend\ItemsProcFunc->getApiKeys'
+                  list_id:
+                    label: flexform.list
+                    config:
+                      type: select
+                      renderType: selectSingle
+                      itemsProcFunc:
+                        'Sup7even\Mailchimp\Hooks\Backend\ItemsProcFunc->getLists'
+                  interest_id:
+                    label: flexform.interests
+                    config:
+                      type: select
+                      renderType: selectSingle
+                      itemsProcFunc:
+                        'Sup7even\Mailchimp\Hooks\Backend\ItemsProcFunc->getInterests'

--- a/Configuration/Yaml/Finishers/Mailchimp.yaml
+++ b/Configuration/Yaml/Finishers/Mailchimp.yaml
@@ -44,16 +44,24 @@ TYPO3:
                       default: 0
                   api_key:
                     label: flexform.apiKey
+                    onChange: reload
                     config:
                       type: select
                       renderType: selectSingle
+                      items:
+                        10:
+                          -
                       itemsProcFunc:
                         'Sup7even\Mailchimp\Hooks\Backend\ItemsProcFunc->getApiKeys'
                   list_id:
                     label: flexform.list
+                    onChange: reload
                     config:
                       type: select
                       renderType: selectSingle
+                      items:
+                        10:
+                          -
                       itemsProcFunc:
                         'Sup7even\Mailchimp\Hooks\Backend\ItemsProcFunc->getLists'
                   interest_id:
@@ -61,5 +69,8 @@ TYPO3:
                     config:
                       type: select
                       renderType: selectSingle
+                      items:
+                        10:
+                          -
                       itemsProcFunc:
                         'Sup7even\Mailchimp\Hooks\Backend\ItemsProcFunc->getInterests'

--- a/Configuration/Yaml/Finishers/Mailchimp.yaml
+++ b/Configuration/Yaml/Finishers/Mailchimp.yaml
@@ -1,0 +1,35 @@
+TYPO3:
+  CMS:
+    Form:
+      prototypes:
+        standard:
+          finishersDefinition:
+            Mailchimp:
+              implementationClassName: Sup7even\Mailchimp\Domain\Finishers\MailchimpFinisher
+              options: 
+                first_name: ''
+                last_name: ''
+                email: ''
+              formEditor:
+                iconIdentifier: form-finisher
+                label: formEditor.elements.Form.finisher.Mailchimp.editor.header.label
+                predefinedDefaults:
+                  options:
+                    first_name: ''
+                    last_name: ''
+                    email: ''
+              FormEngine:
+                label: formEditor.elements.Form.finisher.Mailchimp.editor.header.label
+                elements:
+                  first_name:
+                    label: formEditor.elements.Form.finisher.Mailchimp.editor.first_name.label
+                    config:
+                      type: input
+                  last_name:
+                    label: formEditor.elements.Form.finisher.Mailchimp.editor.last_name.label
+                    config:
+                      type: input
+                  email:
+                    label: formEditor.elements.Form.finisher.Mailchimp.editor.email.label
+                    config:
+                      type: input

--- a/Configuration/Yaml/FormElements/Interests.yaml
+++ b/Configuration/Yaml/FormElements/Interests.yaml
@@ -1,0 +1,33 @@
+TYPO3:
+  CMS:
+    Form:
+      prototypes:
+        standard:
+          formElementsDefinition:
+            Interests:
+              formEditor:
+                predefinedDefaults:
+                  properties:
+                    requiredFields: []
+                editors:
+                  100:
+                    identifier: header
+                    templateName: Inspector-FormElementHeaderEditor
+                  200:
+                    identifier: label
+                    templateName: Inspector-TextEditor
+                    label: formEditor.elements.FormElement.editor.label.label
+                    propertyPath: label
+                  9999:
+                    identifier: removeButton
+                    templateName: Inspector-RemoveElementEditor
+                label: field.interests
+                group: select
+                groupSorting: 600
+                iconIdentifier: form-checkbox
+              renderingOptions:
+                
+              implementationClassName: Sup7even\Mailchimp\Domain\Model\FormElements\Interests
+          formEditor:
+            formEditorPartials:
+              FormElement-Interests: Stage/SimpleTemplate

--- a/Configuration/Yaml/FormElements/Interests.yaml
+++ b/Configuration/Yaml/FormElements/Interests.yaml
@@ -79,7 +79,7 @@ TYPO3:
                         9999:
                           identifier: removeButton
                           templateName: Inspector-RemoveElementEditor
-                label: field.interests
+                label: formEditor.elements.Interests.label
                 group: select
                 groupSorting: 600
                 iconIdentifier: form-checkbox

--- a/Configuration/Yaml/FormElements/Interests.yaml
+++ b/Configuration/Yaml/FormElements/Interests.yaml
@@ -9,6 +9,7 @@ TYPO3:
                 predefinedDefaults:
                   properties:
                     requiredFields: []
+                    useGroupName: false
                 editors:
                   100:
                     identifier: header
@@ -18,9 +19,66 @@ TYPO3:
                     templateName: Inspector-TextEditor
                     label: formEditor.elements.FormElement.editor.label.label
                     propertyPath: label
+                  210:
+                    identifier: useGroupName
+                    templateName: Inspector-CheckboxEditor
+                    label: formEditor.elements.FormElement.editor.useGroupName.label
+                    propertyPath: properties.useGroupName
+                    fieldExplanationText: formEditor.elements.FormElement.editor.useGroupName.fieldExplanationText
+                  230:
+                    identifier: elementDescription
+                    templateName: Inspector-TextEditor
+                    label: formEditor.elements.FormElement.editor.elementDescription.label
+                    propertyPath: properties.elementDescription
+                  900:
+                    identifier: validators
+                    templateName: Inspector-ValidatorsEditor
+                    label: formEditor.elements.MultiSelectionMixin.editor.validators.label
+                    selectOptions:
+                      10:
+                        value: ''
+                        label: formEditor.elements.MultiSelectionMixin.editor.validators.EmptyValue.label
+                      20:
+                        value: Count
+                        label: formEditor.elements.MultiSelectionMixin.editor.validators.Count.label
                   9999:
                     identifier: removeButton
                     templateName: Inspector-RemoveElementEditor
+                propertyCollections:
+                  validators:
+                    10:
+                      identifier: Count
+                      editors:
+                        100:
+                          identifier: header
+                          templateName: Inspector-CollectionElementHeaderEditor
+                          label: formEditor.elements.MultiSelectionMixin.validators.Count.editor.header.label
+                        200:
+                          identifier: minimum
+                          templateName: Inspector-TextEditor
+                          label: formEditor.elements.MinimumMaximumEditorsMixin.editor.minimum.label
+                          propertyPath: options.minimum
+                          propertyValidators:
+                            10: Integer
+                        300:
+                          identifier: maximum
+                          templateName: Inspector-TextEditor
+                          label: formEditor.elements.MinimumMaximumEditorsMixin.editor.maximum.label
+                          propertyPath: options.maximum
+                          propertyValidators:
+                            10: Integer
+                        400:
+                          identifier: validationErrorMessage
+                          templateName: Inspector-ValidationErrorMessageEditor
+                          label: formEditor.elements.MultiSelectionMixin.validators.Count.editor.validationErrorMessage.label
+                          fieldExplanationText: formEditor.elements.MultiSelectionMixin.validators.Count.editor.validationErrorMessage.fieldExplanationText
+                          errorCodes:
+                            10: 1627938559
+                            20: 1627938566
+                          propertyPath: properties.validationErrorMessages
+                        9999:
+                          identifier: removeButton
+                          templateName: Inspector-RemoveElementEditor
                 label: field.interests
                 group: select
                 groupSorting: 600

--- a/Configuration/Yaml/FormSetup.yaml
+++ b/Configuration/Yaml/FormSetup.yaml
@@ -1,0 +1,63 @@
+imports:
+  - { resource: "./Finishers/Mailchimp.yaml" }
+
+TYPO3:
+  CMS:
+    Form:
+      prototypes:
+        standard:
+          formEditor:
+            translationFiles:
+              1627404338: 'EXT:mailchimp/Resources/Private/Language/locallang.xlf'
+          formEngine:
+            translationFiles:
+              1627404338: 'EXT:mailchimp/Resources/Private/Language/locallang.xlf'
+          formElementsDefinition:
+            Form:
+              formEditor:
+                editors:
+                  900:
+                    identifier: finishers
+                    templateName: Inspector-FinishersEditor
+                    label: formEditor.elements.Form.editor.finishers.label
+                    selectOptions:
+                      1627404338:
+                        value: Mailchimp
+                        label: formEditor.elements.Form.editor.finishers.Mailchimp.label
+                propertyCollections:
+                  finishers:
+                    1627404338:
+                      identifier: Mailchimp
+                      editors:
+                        100:
+                          identifier: header
+                          templateName: Inspector-CollectionElementHeaderEditor
+                          label: formEditor.elements.Form.finisher.Mailchimp.editor.header.label
+                        200:
+                          identifier: first_name
+                          templateName: Inspector-TextEditor
+                          label: formEditor.elements.Form.finisher.Mailchimp.editor.first_name.label
+                          propertyPath: options.first_name
+                          enableFormelementSelectionButton: true
+                        300:
+                          identifier: last_name
+                          templateName: Inspector-TextEditor
+                          label: formEditor.elements.Form.finisher.Mailchimp.editor.last_name.label
+                          propertyPath: options.last_name
+                          enableFormelementSelectionButton: true
+                        400:
+                          identifier: email
+                          templateName: Inspector-TextEditor
+                          label: formEditor.elements.Form.finisher.Mailchimp.editor.email.label
+                          propertyPath: options.email
+                          enableFormelementSelectionButton: true
+                        9999:
+                          identifier: removeButton
+                          templateName: Inspector-RemoveElementEditor
+              renderingOptions:
+                translation:
+                  translationFiles:
+                    1627404338: 'EXT:mailchimp/Resources/Private/Language/locallang.xlf'
+      formManager:
+        translationFiles:
+          1627404338: 'EXT:mailchimp/Resources/Private/Language/locallang.xlf'

--- a/Configuration/Yaml/FormSetup.yaml
+++ b/Configuration/Yaml/FormSetup.yaml
@@ -17,13 +17,10 @@ TYPO3:
               formEditor:
                 editors:
                   900:
-                    identifier: finishers
-                    templateName: Inspector-FinishersEditor
-                    label: formEditor.elements.Form.editor.finishers.label
                     selectOptions:
                       1627404338:
                         value: Mailchimp
-                        label: formEditor.elements.Form.editor.finishers.Mailchimp.label
+                        label: plugin.title
                 propertyCollections:
                   finishers:
                     1627404338:
@@ -32,25 +29,30 @@ TYPO3:
                         100:
                           identifier: header
                           templateName: Inspector-CollectionElementHeaderEditor
-                          label: formEditor.elements.Form.finisher.Mailchimp.editor.header.label
+                          label: plugin.title
                         200:
                           identifier: first_name
                           templateName: Inspector-TextEditor
-                          label: formEditor.elements.Form.finisher.Mailchimp.editor.first_name.label
+                          label: field.firstName
                           propertyPath: options.first_name
                           enableFormelementSelectionButton: true
                         300:
                           identifier: last_name
                           templateName: Inspector-TextEditor
-                          label: formEditor.elements.Form.finisher.Mailchimp.editor.last_name.label
+                          label: field.lastName
                           propertyPath: options.last_name
                           enableFormelementSelectionButton: true
                         400:
                           identifier: email
                           templateName: Inspector-TextEditor
-                          label: formEditor.elements.Form.finisher.Mailchimp.editor.email.label
+                          label: field.email
                           propertyPath: options.email
                           enableFormelementSelectionButton: true
+                        500:
+                          identifier: skip_double_optin
+                          templateName: Inspector-CheckboxEditor
+                          label: field.skipDoubleOptin
+                          propertyPath: options.skip_double_optin
                         9999:
                           identifier: removeButton
                           templateName: Inspector-RemoveElementEditor

--- a/Configuration/Yaml/FormSetup.yaml
+++ b/Configuration/Yaml/FormSetup.yaml
@@ -1,5 +1,6 @@
 imports:
   - { resource: "./Finishers/Mailchimp.yaml" }
+  - { resource: "./FormElements/Interests.yaml" }
 
 TYPO3:
   CMS:
@@ -9,6 +10,9 @@ TYPO3:
           formEditor:
             translationFiles:
               1627404338: 'EXT:mailchimp/Resources/Private/Language/locallang.xlf'
+            dynamicRequireJsModules:
+              additionalViewModelModules:
+                1627661598: 'TYPO3/CMS/Mailchimp/Backend/FormEditor/ViewModel'
           formEngine:
             translationFiles:
               1627404338: 'EXT:mailchimp/Resources/Private/Language/locallang.xlf'
@@ -53,10 +57,18 @@ TYPO3:
                           templateName: Inspector-CheckboxEditor
                           label: field.skipDoubleOptin
                           propertyPath: options.skip_double_optin
+                        600:
+                          identifier: interests
+                          templateName: Inspector-TextEditor
+                          label: field.interestChoices
+                          propertyPath: options.interests
+                          enableFormelementSelectionButton: true
                         9999:
                           identifier: removeButton
                           templateName: Inspector-RemoveElementEditor
               renderingOptions:
+                partialRootPaths:
+                  1627662229: 'EXT:mailchimp/Resources/Private/Partials/Form/'
                 translation:
                   translationFiles:
                     1627404338: 'EXT:mailchimp/Resources/Private/Language/locallang.xlf'

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -90,6 +90,9 @@
    <trans-unit id="formEditor.elements.FormElement.editor.useGroupName.fieldExplanationText" resname="formEditor.elements.FormElement.editor.useGroupName.fieldExplanationText">
     <source>Use the group name in Mailchimp's interface instead of the label field</source>
    </trans-unit>
+   <trans-unit id="formEditor.elements.Interests.label" resname="formEditor.elements.Interests.label" xml:space="preserve">
+    <source>Mailchimp Interests</source>
+    </trans-unit>
   </body>
  </file>
 </xliff>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -78,8 +78,11 @@
    <trans-unit id="success.title" resname="success.title">
     <source>You have successfully registered!</source>
    </trans-unit>
-   <trans-unit id="field.skipDoubleOptin">
+   <trans-unit id="field.skipDoubleOptin" resname="field.skipDoubleOptin">
     <source>Skip double opt-in</source>
+   </trans-unit>
+   <trans-unit id="field.interestChoices" resname="field.interestChoices">
+    <source>Interest choices</source>
    </trans-unit>
   </body>
  </file>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -78,20 +78,8 @@
    <trans-unit id="success.title" resname="success.title">
     <source>You have successfully registered!</source>
    </trans-unit>
-   <trans-unit id="formEditor.elements.Form.finisher.Mailchimp.editor.header.label" resname="formEditor.elements.Form.finisher.Mailchimp.editor.header.label">
-    <source>Mailchimp</source>
-   </trans-unit>
-   <trans-unit id="formEditor.elements.Form.editor.finishers.Mailchimp.label" resname="formEditor.elements.Form.editor.finishers.Mailchimp.label">
-    <source>Mailchimp</source>
-   </trans-unit>
-   <trans-unit id="formEditor.elements.Form.finisher.Mailchimp.editor.first_name.label" resname="formEditor.elements.Form.finisher.Mailchimp.editor.first_name.label">
-    <source>First name</source>
-   </trans-unit>
-   <trans-unit id="formEditor.elements.Form.finisher.Mailchimp.editor.last_name.label" resname="formEditor.elements.Form.finisher.Mailchimp.editor.last_name.label">
-    <source>Last name</source>
-   </trans-unit>
-   <trans-unit id="formEditor.elements.Form.finisher.Mailchimp.editor.email.label" resname="formEditor.elements.Form.finisher.Mailchimp.editor.email.label">
-    <source>Email address</source>
+   <trans-unit id="field.skipDoubleOptin">
+    <source>Skip double opt-in</source>
    </trans-unit>
   </body>
  </file>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -78,6 +78,21 @@
    <trans-unit id="success.title" resname="success.title">
     <source>You have successfully registered!</source>
    </trans-unit>
+   <trans-unit id="formEditor.elements.Form.finisher.Mailchimp.editor.header.label" resname="formEditor.elements.Form.finisher.Mailchimp.editor.header.label">
+    <source>Mailchimp</source>
+   </trans-unit>
+   <trans-unit id="formEditor.elements.Form.editor.finishers.Mailchimp.label" resname="formEditor.elements.Form.editor.finishers.Mailchimp.label">
+    <source>Mailchimp</source>
+   </trans-unit>
+   <trans-unit id="formEditor.elements.Form.finisher.Mailchimp.editor.first_name.label" resname="formEditor.elements.Form.finisher.Mailchimp.editor.first_name.label">
+    <source>First name</source>
+   </trans-unit>
+   <trans-unit id="formEditor.elements.Form.finisher.Mailchimp.editor.last_name.label" resname="formEditor.elements.Form.finisher.Mailchimp.editor.last_name.label">
+    <source>Last name</source>
+   </trans-unit>
+   <trans-unit id="formEditor.elements.Form.finisher.Mailchimp.editor.email.label" resname="formEditor.elements.Form.finisher.Mailchimp.editor.email.label">
+    <source>Email address</source>
+   </trans-unit>
   </body>
  </file>
 </xliff>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -84,6 +84,12 @@
    <trans-unit id="field.interestChoices" resname="field.interestChoices">
     <source>Interest choices</source>
    </trans-unit>
+   <trans-unit id="formEditor.elements.FormElement.editor.useGroupName.label" resname="formEditor.elements.FormElement.editor.useGroupName.label">
+    <source>Use group name as label</source>
+   </trans-unit>
+   <trans-unit id="formEditor.elements.FormElement.editor.useGroupName.fieldExplanationText" resname="formEditor.elements.FormElement.editor.useGroupName.fieldExplanationText">
+    <source>Use the group name in Mailchimp's interface instead of the label field</source>
+   </trans-unit>
   </body>
  </file>
 </xliff>

--- a/Resources/Private/Partials/Form/Interests.html
+++ b/Resources/Private/Partials/Form/Interests.html
@@ -1,0 +1,90 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+      xmlns:formvh="http://typo3.org/ns/TYPO3/CMS/Form/ViewHelpers"
+      xmlns:mc="http://typo3.org/ns/Sup7even/Mailchimp/ViewHelpers"
+      data-namespace-typo3-fluid="true">
+
+    <f:variable name="interests">{element.properties}</f:variable>
+
+    <formvh:renderRenderable renderable="{element}">
+        <f:render partial="Field/Field" arguments="{element: element}" contentAs="elementContent">
+            <f:if condition="{interests}">
+                <f:switch expression="{interests.type}">
+                    <f:case value="checkboxes">
+                        <f:render section="interestType-checkboxes" arguments="{_all}"/>
+                    </f:case>
+                    <f:case value="radio">
+                        <f:render section="interestType-radio" arguments="{_all}"/>
+                    </f:case>
+                    <f:case value="dropdown">
+                        <f:render section="interestType-dropdown" arguments="{_all}"/>
+                    </f:case>
+                    <f:case value="hidden">
+                        <f:comment><!-- do nothing --></f:comment>
+                    </f:case>
+                </f:switch>
+            </f:if>
+        </f:render>
+    </formvh:renderRenderable>
+
+    <f:section name="interestType-checkboxes">
+        <div id="{element.uniqueIdentifier}" class="inputs-list">
+            <f:for each="{element.properties.options}" as="label" key="value" iteration="idIterator">
+                <div class="form-check">
+                    <label class="form-check-label" for="{element.uniqueIdentifier}-{idIterator.index}">
+                        <f:form.checkbox
+                            property="{element.identifier}"
+                            multiple="1"
+                            id="{element.uniqueIdentifier}-{idIterator.index}"
+                            class="{element.properties.elementClassAttribute}"
+                            value="{value}"
+                            errorClass="{element.properties.elementErrorClassAttribute}"
+                            additionalAttributes="{formvh:translateElementProperty(element: element, property: 'fluidAdditionalAttributes')}"
+                        />
+                        <span>{formvh:translateElementProperty(element: element, property: '{0: \'options\', 1: value}')}</span>
+                    </label>
+                </div>
+            </f:for>
+        </div>
+    </f:section>
+
+    <f:section name="interestType-radio">
+        <label class="control-label">{formvh:translateElementProperty(element: element, property: 'label')}<f:if condition="{element.required}"><f:render partial="Field/Required" /></f:if></label>
+        <div class="{element.properties.containerClassAttribute}">
+            <div id="{element.uniqueIdentifier}" class="inputs-list">
+                <div class="form-group">
+                    <f:for each="{element.properties.options}" as="label" key="value" iteration="idIterator">
+                        <div class="radio">
+                            <label for="{element.uniqueIdentifier}-{idIterator.index}">
+                                <f:form.radio
+                                    property="{element.identifier}"
+                                    id="{element.uniqueIdentifier}-{idIterator.index}"
+                                    class="{element.properties.elementClassAttribute} form-check-input"
+                                    value="{value}"
+                                    errorClass="{element.properties.elementErrorClassAttribute}"
+                                    additionalAttributes="{formvh:translateElementProperty(element: element, property: 'fluidAdditionalAttributes')}"
+                                />
+                                <span>{formvh:translateElementProperty(element: element, property: '{0: \'options\', 1: value}')}</span>
+                            </label>
+                        </div>
+                    </f:for>
+                </div>
+            </div>
+        </div>
+    </f:section>
+
+    <f:section name="interestType-dropdown">
+        <div class="form-group">
+            <label class="col-sm-3 control-label">{interests.title}</label>
+            <div class="col-sm-9">
+                <f:form.select
+                    property="{element.identifier}"
+                    id="{element.uniqueIdentifier}"
+                    options="{formvh:translateElementProperty(element: element, property: 'options')}"
+                    class="{element.properties.elementClassAttribute} form-control"
+                    errorClass="{element.properties.elementErrorClassAttribute}"
+                    additionalAttributes="{formvh:translateElementProperty(element: element, property: 'fluidAdditionalAttributes')}"
+            />
+            </div>
+        </div>
+    </f:section>
+</html>

--- a/Resources/Private/Partials/Form/Interests.html
+++ b/Resources/Private/Partials/Form/Interests.html
@@ -4,7 +4,6 @@
       data-namespace-typo3-fluid="true">
 
     <f:variable name="interests">{element.properties}</f:variable>
-
     <formvh:renderRenderable renderable="{element}">
         <f:render partial="Field/Field" arguments="{element: element}" contentAs="elementContent">
             <f:if condition="{interests}">
@@ -74,7 +73,6 @@
 
     <f:section name="interestType-dropdown">
         <div class="form-group">
-            <label class="col-sm-3 control-label">{interests.title}</label>
             <div class="col-sm-9">
                 <f:form.select
                     property="{element.identifier}"

--- a/Resources/Private/Partials/Form/Interests.html
+++ b/Resources/Private/Partials/Form/Interests.html
@@ -34,7 +34,7 @@
                             property="{element.identifier}"
                             multiple="1"
                             id="{element.uniqueIdentifier}-{idIterator.index}"
-                            class="{element.properties.elementClassAttribute}"
+                            class="{element.properties.elementClassAttribute} form-check-input"
                             value="{value}"
                             errorClass="{element.properties.elementErrorClassAttribute}"
                             additionalAttributes="{formvh:translateElementProperty(element: element, property: 'fluidAdditionalAttributes')}"

--- a/Resources/Public/JavaScript/Backend/FormEditor/ViewModel.js
+++ b/Resources/Public/JavaScript/Backend/FormEditor/ViewModel.js
@@ -1,0 +1,106 @@
+define([
+    'jquery',
+    'TYPO3/CMS/Form/Backend/FormEditor/StageComponent'
+], function ($, StageComponent) {
+    'use strict';
+
+    return (function ($, StageComponent) {
+
+        /**
+         * @private
+         *
+         * @var object
+         */
+        var _formEditorApp = null;
+
+        /**
+         * @private
+         *
+         * @return object
+         */
+        function getFormEditorApp() {
+            return _formEditorApp;
+        };
+
+        /**
+         * @private
+         *
+         * @return object
+         */
+        function getPublisherSubscriber() {
+            return getFormEditorApp().getPublisherSubscriber();
+        };
+
+        /**
+         * @private
+         *
+         * @return object
+         */
+        function getUtility() {
+            return getFormEditorApp().getUtility();
+        };
+
+        /**
+         * @private
+         *
+         * @return object
+         */
+        function getCurrentlySelectedFormElement() {
+            return getFormEditorApp().getCurrentlySelectedFormElement();
+        };
+
+        /**
+         * @private
+         *
+         * @param mixed test
+         * @param string message
+         * @param int messageCode
+         * @return void
+         */
+        function assert(test, message, messageCode) {
+            return getFormEditorApp().assert(test, message, messageCode);
+        };
+
+
+        /**
+         * @private
+         *
+         * @return void
+         */
+        function _subscribeEvents() {
+            /**
+             * @private
+             *
+             * @param string
+             * @param array
+             *              args[0] = formElement
+             *              args[1] = template
+             * @return void
+             */
+            getPublisherSubscriber().subscribe('view/stage/abstract/render/template/perform', function (topic, args) {
+                if (args[0].get('type') === 'Interests') {
+                    StageComponent.renderSimpleTemplate(args[0], args[1]);
+                }
+            });
+        };
+
+        /**
+         * @public
+         *
+         * @param object formEditorApp
+         * @return void
+         */
+        function bootstrap(formEditorApp) {
+            _formEditorApp = formEditorApp;
+            _subscribeEvents();
+        };
+
+        /**
+         * Publish the public methods.
+         * Implements the "Revealing Module Pattern".
+         */
+        return {
+            bootstrap: bootstrap
+        };
+    })($, StageComponent);
+});

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -20,7 +20,7 @@ $iconRegistry->registerIcon(
 
 // Page module hook
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms/layout/class.tx_cms_layout.php']['list_type_Info']['mailchimp_registration']['mailchimp'] =
-    \Sup7even\Mailchimp\Hooks\Backend\PageLayoutViewHook::class . '->getExtensionSummary';
+    \Sup7even\Mailchimp\Hooks\Backend\PageLayoutViewHook::class.'->getExtensionSummary';
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig('<INCLUDE_TYPOSCRIPT: source="FILE:EXT:mailchimp/Configuration/TSconfig/ContentElementWizard.tsconfig">');
 

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -23,3 +23,7 @@ $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms/layout/class.tx_cms_layout.php'][
     \Sup7even\Mailchimp\Hooks\Backend\PageLayoutViewHook::class . '->getExtensionSummary';
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig('<INCLUDE_TYPOSCRIPT: source="FILE:EXT:mailchimp/Configuration/TSconfig/ContentElementWizard.tsconfig">');
+
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScriptSetup(
+    'module.tx_form.settings.yamlConfigurations.1627403947 = EXT:mailchimp/Configuration/Yaml/FormSetup.yaml'
+);

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -28,3 +28,5 @@ $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms/layout/class.tx_cms_layout.php'][
     'module.tx_form.settings.yamlConfigurations.1627403947 = EXT:mailchimp/Configuration/Yaml/FormSetup.yaml
     plugin.tx_form.settings.yamlConfigurations.1627403947 = EXT:mailchimp/Configuration/Yaml/FormSetup.yaml'
 );
+
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/form']['afterBuildingFinished'][1627589455] = \Sup7even\Mailchimp\Hooks\Frontend\Form::class;

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -25,5 +25,6 @@ $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms/layout/class.tx_cms_layout.php'][
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig('<INCLUDE_TYPOSCRIPT: source="FILE:EXT:mailchimp/Configuration/TSconfig/ContentElementWizard.tsconfig">');
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScriptSetup(
-    'module.tx_form.settings.yamlConfigurations.1627403947 = EXT:mailchimp/Configuration/Yaml/FormSetup.yaml'
+    'module.tx_form.settings.yamlConfigurations.1627403947 = EXT:mailchimp/Configuration/Yaml/FormSetup.yaml
+    plugin.tx_form.settings.yamlConfigurations.1627403947 = EXT:mailchimp/Configuration/Yaml/FormSetup.yaml'
 );


### PR DESCRIPTION
Implements a Finisher which accepts first name, last name, email and Interests selection as options. These additions essentially allow the user to reimagine the existing form—provided by the `mailchimp_registration` plugin—in the Form Framework. This allows for cohesion with the rest of a site's forms and styles, removing the need to create a separate form for just Mailchimp.

Caveat: Used API, List, and Interests (`api_key`, `list_id`, `interest_id`) must still be configured in the Flexform/Finisher override as opposed to the Forms module. 
![flexform options available](https://github.com/supseven-at/mailchimp/assets/60153014/a8c13b11-3365-4c42-bf20-51131dde366d)
![ext:form options missing](https://github.com/supseven-at/mailchimp/assets/60153014/39c0e2b2-c522-4d74-8623-5cadd05f5806)

I don't see that problem being resolved until ext:form adds hooks similar to ItemsProcFunc for the Form editor.